### PR TITLE
Illustrated dice distributions

### DIFF
--- a/Articles/2024-NonAdditiveProbability/NonAdditiveProbability.tex
+++ b/Articles/2024-NonAdditiveProbability/NonAdditiveProbability.tex
@@ -400,6 +400,22 @@ Note that the linearity in our axioms is in terms of mixing coefficients, not pr
 		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
 		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1/5) (2, 1/5) (3, 1/5) (4, 1/5) (5, 1/5) (6, 1/5)};
 	\end{tikzpicture}
+	$= \frac{1}{6}$
+	\begin{tikzpicture}[y=3ex, x=\xstep]
+		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
+		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1)};
+	\end{tikzpicture}
+	$+ \frac{5}{6}$
+	\begin{tikzpicture}[y=3ex, x=\xstep]
+		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
+		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(2, 1/5) (3, 1/4) (4, 1/5) (5, 1/5) (6, 1/5)};
+	\end{tikzpicture}
+	
+	\vspace{0.3cm}
+	\begin{tikzpicture}[y=3ex, x=\xstep]
+		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
+		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1/5) (2, 1/5) (3, 1/5) (4, 1/5) (5, 1/5) (6, 1/5)};
+	\end{tikzpicture}
 	$= \frac{1}{3}$
 	\begin{tikzpicture}[y=3ex, x=\xstep]
 		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);

--- a/Articles/2024-NonAdditiveProbability/NonAdditiveProbability.tex
+++ b/Articles/2024-NonAdditiveProbability/NonAdditiveProbability.tex
@@ -392,7 +392,25 @@ As a comparison, in the previous case all probability measures were given over a
 
 Note that the linearity in our axioms is in terms of mixing coefficients, not probability of outcomes. That is, regardless of whether we can characterize experiment outcomes with probability distributions, preparation procedures will always allow us to create a statistical mixture. As we saw in Choquet theory, the difficulty is that there are multiple ways to mix pure states to recover the same ensemble. However, the question of what is the biggest mixture coefficient one can use in a specific case is well-defined, and generalizes to the non-compact case as well. Therefore, our generalization of probability is not in terms of what an ensemble can lead to (i.e. measurements), but in terms of how ensembles can be produced (i.e. preparations).
 
-\textbf{Fraction capacity.} Let us concentrate on the following problem: given an ensemble $\ens \in \Ens$ and a (Borel) set of ensembles $A \subseteq \Ens$, what fraction of $\ens$ can be constructed by a mixture of $A$? How much of $\ens$ can be explained as coming from preparations corresponding to $A$? For example, let $\Ens$ be the space of all probability distributions for a six-sided die. Let $\ens_{123456}$ be the uniform distribution over all outcomes. Let $A_1 = \{\ens_1\}$ where $\ens_1$ represents outcome one with 100\% probability. Since we can write $\ens_{123456} = \frac{1}{6} \ens_{1} + \frac{5}{6} \ens_{23456}$, where $\ens_{23456}$ represents a uniform distributions over the five outcomes, $1/6$ of $\ens$ can be constructed from $A$, but no more. Similarly, if $A_{12} = \{\ens_{1},\ens_{2}\}$, we can write $\ens = \frac{1}{3} \left(\frac{1}{2} \ens_1 + \frac{1}{2} \ens_2 \right)  + \frac{2}{3} \ens_{3456}$, so $1/3$ of $\ens$ can be constructed from $A$, but no more. Note that, given the uniform distribution, $1/6$ is exactly the probability for the event $A_1$ and $1/3$ the probability for event $A_{12}$. This gives the basic insight for our definitions.
+\textbf{Fraction capacity.} Let us concentrate on the following problem: given an ensemble $\ens \in \Ens$ and a (Borel) set of ensembles $A \subseteq \Ens$, what fraction of $\ens$ can be constructed by a mixture of $A$? How much of $\ens$ can be explained as coming from preparations corresponding to $A$? For example, let $\Ens$ be the space of all probability distributions for a six-sided die. Let $\ens_{123456}$ be the uniform distribution over all outcomes. Let $A_1 = \{\ens_1\}$ where $\ens_1$ represents outcome one with 100\% probability. Since we can write $\ens_{123456} = \frac{1}{6} \ens_{1} + \frac{5}{6} \ens_{23456}$ (see \eqref{eq:dice} for an illustration), where $\ens_{23456}$ represents a uniform distributions over the five outcomes, $1/5$ of $\ens$ can be constructed from $A$, but no more. Similarly, if $A_{12} = \{\ens_{1},\ens_{2}\}$, we can write $\ens = \frac{1}{3} \left(\frac{1}{2} \ens_1 + \frac{1}{2} \ens_2 \right)  + \frac{2}{3} \ens_{3456}$, so $1/3$ of $\ens$ can be constructed from $A$, but no more. Note that, given the uniform distribution, $1/5$ is exactly the probability for the event $A_1$ and $1/3$ the probability for event $A_{12}$. This gives the basic insight for our definitions.
+
+\begin{equation}\label{eq:dice}
+	\def\xstep{0.75em}
+	\begin{tikzpicture}[y=3ex, x=\xstep]
+		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
+		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1/5) (2, 1/5) (3, 1/5) (4, 1/5) (5, 1/5) (6, 1/5)};
+	\end{tikzpicture}
+	= \frac{1}{6}
+	\begin{tikzpicture}[y=3ex, x=\xstep]
+		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
+		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1)};
+	\end{tikzpicture}
+	+ \frac{5}{6}
+	\begin{tikzpicture}[y=3ex, x=\xstep]
+		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
+		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(2, 1/5) (3, 1/5) (4, 1/5) (5, 1/5) (6, 1/5)};
+	\end{tikzpicture}
+\end{equation}
 
 Given a target ensemble $\ens \in \Ens$ and an arbitrary ensemble $\ens[a] \in \Ens$, we define the \textbf{fraction} of $\ens[a]$ in $\ens$ to be
 \begin{equation}

--- a/Articles/2024-NonAdditiveProbability/NonAdditiveProbability.tex
+++ b/Articles/2024-NonAdditiveProbability/NonAdditiveProbability.tex
@@ -403,12 +403,12 @@ Note that the linearity in our axioms is in terms of mixing coefficients, not pr
 	$= \frac{1}{6}$
 	\begin{tikzpicture}[y=3ex, x=\xstep]
 		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
-		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1)};
+		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(3, 1)};
 	\end{tikzpicture}
 	$+ \frac{5}{6}$
 	\begin{tikzpicture}[y=3ex, x=\xstep]
 		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
-		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(2, 1/5) (3, 1/4) (4, 1/5) (5, 1/5) (6, 1/5)};
+		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1/5) (2, 1/4) (4, 1/5) (5, 1/5) (6, 1/5)};
 	\end{tikzpicture}
 	
 	\vspace{0.3cm}

--- a/Articles/2024-NonAdditiveProbability/NonAdditiveProbability.tex
+++ b/Articles/2024-NonAdditiveProbability/NonAdditiveProbability.tex
@@ -392,25 +392,26 @@ As a comparison, in the previous case all probability measures were given over a
 
 Note that the linearity in our axioms is in terms of mixing coefficients, not probability of outcomes. That is, regardless of whether we can characterize experiment outcomes with probability distributions, preparation procedures will always allow us to create a statistical mixture. As we saw in Choquet theory, the difficulty is that there are multiple ways to mix pure states to recover the same ensemble. However, the question of what is the biggest mixture coefficient one can use in a specific case is well-defined, and generalizes to the non-compact case as well. Therefore, our generalization of probability is not in terms of what an ensemble can lead to (i.e. measurements), but in terms of how ensembles can be produced (i.e. preparations).
 
-\textbf{Fraction capacity.} Let us concentrate on the following problem: given an ensemble $\ens \in \Ens$ and a (Borel) set of ensembles $A \subseteq \Ens$, what fraction of $\ens$ can be constructed by a mixture of $A$? How much of $\ens$ can be explained as coming from preparations corresponding to $A$? For example, let $\Ens$ be the space of all probability distributions for a six-sided die. Let $\ens_{123456}$ be the uniform distribution over all outcomes. Let $A_1 = \{\ens_1\}$ where $\ens_1$ represents outcome one with 100\% probability. Since we can write $\ens_{123456} = \frac{1}{6} \ens_{1} + \frac{5}{6} \ens_{23456}$ (see \eqref{eq:dice} for an illustration), where $\ens_{23456}$ represents a uniform distributions over the five outcomes, $1/5$ of $\ens$ can be constructed from $A$, but no more. Similarly, if $A_{12} = \{\ens_{1},\ens_{2}\}$, we can write $\ens = \frac{1}{3} \left(\frac{1}{2} \ens_1 + \frac{1}{2} \ens_2 \right)  + \frac{2}{3} \ens_{3456}$, so $1/3$ of $\ens$ can be constructed from $A$, but no more. Note that, given the uniform distribution, $1/5$ is exactly the probability for the event $A_1$ and $1/3$ the probability for event $A_{12}$. This gives the basic insight for our definitions.
+\textbf{Fraction capacity.} Let us concentrate on the following problem: given an ensemble $\ens \in \Ens$ and a (Borel) set of ensembles $A \subseteq \Ens$, what fraction of $\ens$ can be constructed by a mixture of $A$? How much of $\ens$ can be explained as coming from preparations corresponding to $A$? For example, let $\Ens$ be the space of all probability distributions for a six-sided die. Let $\ens_{123456}$ be the uniform distribution over all outcomes. Let $A_1 = \{\ens_1\}$ where $\ens_1$ represents outcome one with 100\% probability. Since we can write $\ens_{123456} = \frac{1}{6} \ens_{1} + \frac{5}{6} \ens_{23456}$ (see fig. \ref{fig:dice} for an illustration), where $\ens_{23456}$ represents a uniform distributions over the five outcomes, $1/5$ of $\ens$ can be constructed from $A$, but no more. Similarly, if $A_{12} = \{\ens_{1},\ens_{2}\}$, we can write $\ens = \frac{1}{3} \left(\frac{1}{2} \ens_1 + \frac{1}{2} \ens_2 \right)  + \frac{2}{3} \ens_{3456}$, so $1/3$ of $\ens$ can be constructed from $A$, but no more. Note that, given the uniform distribution, $1/5$ is exactly the probability for the event $A_1$ and $1/3$ the probability for event $A_{12}$. This gives the basic insight for our definitions.
 
-\begin{equation}\label{eq:dice}
+\begin{figure}
 	\def\xstep{0.75em}
 	\begin{tikzpicture}[y=3ex, x=\xstep]
 		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
 		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1/5) (2, 1/5) (3, 1/5) (4, 1/5) (5, 1/5) (6, 1/5)};
 	\end{tikzpicture}
-	= \frac{1}{6}
+	$= \frac{1}{6}$
 	\begin{tikzpicture}[y=3ex, x=\xstep]
 		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
 		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1)};
 	\end{tikzpicture}
-	+ \frac{5}{6}
+	$+ \frac{5}{6}$
 	\begin{tikzpicture}[y=3ex, x=\xstep]
 		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
 		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(2, 1/5) (3, 1/5) (4, 1/5) (5, 1/5) (6, 1/5)};
 	\end{tikzpicture}
-\end{equation}
+	\caption{Illustration of the mixture of distributions}\label{fig:dice}
+\end{figure}
 
 Given a target ensemble $\ens \in \Ens$ and an arbitrary ensemble $\ens[a] \in \Ens$, we define the \textbf{fraction} of $\ens[a]$ in $\ens$ to be
 \begin{equation}

--- a/Articles/2024-NonAdditiveProbability/NonAdditiveProbability.tex
+++ b/Articles/2024-NonAdditiveProbability/NonAdditiveProbability.tex
@@ -400,15 +400,15 @@ Note that the linearity in our axioms is in terms of mixing coefficients, not pr
 		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
 		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1/5) (2, 1/5) (3, 1/5) (4, 1/5) (5, 1/5) (6, 1/5)};
 	\end{tikzpicture}
-	$= \frac{1}{6}$
+	$= \frac{1}{3}$
 	\begin{tikzpicture}[y=3ex, x=\xstep]
 		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
-		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1)};
+		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(3, 1/2) (4, 1/2)};
 	\end{tikzpicture}
-	$+ \frac{5}{6}$
+	$+ \frac{2}{3}$
 	\begin{tikzpicture}[y=3ex, x=\xstep]
 		\draw (0, 0) foreach \x in {1,...,6} { -- (\x, 0) -- (\x, -0.2) (\x, 0) } -- ++(1, 0);
-		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(2, 1/5) (3, 1/5) (4, 1/5) (5, 1/5) (6, 1/5)};
+		\draw plot[ybar, bar width={\xstep / 2}] coordinates{(1, 1/4) (2, 1/4) (5, 1/4) (6, 1/4)};
 	\end{tikzpicture}
 	\caption{Illustration of the mixture of distributions}\label{fig:dice}
 \end{figure}


### PR DESCRIPTION
I illustrated the distributions on a dice as it was done in the book.

This first draft uses tikz pictures as symbols in an equation, which looks like this:
<img width="692" height="118" alt="image" src="https://github.com/user-attachments/assets/ebeea5cb-935c-401e-8473-6371dc5578e9" />
I can change it to a regular figure if preferred.